### PR TITLE
feat(for_id): Better support for elections that require country data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 build/
 docs/_build/
 .coverage
+htmlcov/

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -38,7 +38,7 @@ class StatementPublishDate(object):
         election_type, poll_date = type_and_poll_date(election_id)
 
         def valid_election_type(el_type):
-            return el_type in self.election_id_lookup or el_type in ["local", "parl"]
+            return el_type in self.election_id_lookup or el_type in ["local", "parl", "europarl"]
 
         def requires_country(el_type):
             return el_type not in self.election_id_lookup
@@ -56,6 +56,8 @@ class StatementPublishDate(object):
             return self.local(poll_date, country=country)
         elif election_type == "parl":
             return self.uk_parliament(poll_date, country=country)
+        elif election_type == "europarl":
+            return None
 
     def northern_ireland_assembly(self, poll_date: date) -> date:
         """

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -28,7 +28,9 @@ class StatementPublishDate(object):
 
     def for_id(self, election_id: str, country: Country = None) -> date:
         """
-        Calculate the publish date for an election given in `uk-election-ids <https://elections.democracyclub.org.uk/reference_definition/>`_ format and an optional country if necessary (for example, local or parliamentary elections), or raise an exception if that election id is ambiguous (could correspond to elections in multiple countries with different electoral legislation)
+        Calculate the publish date for an election given in `uk-election-ids <https://elections.democracyclub.org.uk/reference_definition/>`_ format and an optional country if necessary (for example, local or parliamentary elections).
+
+        This function returns *None* for elections to the European Parliament, and will raise an exception if the election id is ambiguous (could correspond to elections in multiple countries with different electoral legislation).
 
         :param election_id: a string representing an election id in uk-election-ids format
         :param country: an optional Country representing the country where the election will be held

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -26,23 +26,16 @@ class StatementPublishDate(object):
         }
         self.calendar = UnitedKingdomBankHolidays()
 
-    def for_id(self, election_id: str, country: str = None) -> date:
+    def for_id(self, election_id: str, country: Country = None) -> date:
         """
         Calculate the publish date for an election given in `uk-election-ids <https://elections.democracyclub.org.uk/reference_definition/>`_ format and an optional country if necessary (for example, local or parliamentary elections), or raise an exception if that election id is ambiguous (could correspond to elections in multiple countries with different electoral legislation)
 
         :param election_id: a string representing an election id in uk-election-ids format
-        :param country: an optional string representing the country where the election will be held
+        :param country: an optional Country representing the country where the election will be held
         :return: a datetime representing the expected publish date
         """
 
         election_type, poll_date = type_and_poll_date(election_id)
-
-        countries = {
-            "ENG": Country.ENGLAND,
-            "WLS": Country.WALES,
-            "SCT": Country.SCOTLAND,
-            "NIR": Country.NORTHERN_IRELAND,
-        }
 
         def valid_election_type(el_type):
             return el_type in self.election_id_lookup or el_type in ["local", "parl"]
@@ -53,20 +46,16 @@ class StatementPublishDate(object):
         if not valid_election_type(election_type):
             raise NoSuchElectionTypeError(election_type)
 
-        if requires_country(election_type) and (
-            country is None or country not in countries
-        ):
-            raise AmbiguousElectionIdError(election_id, country)
+        if requires_country(election_type) and country is None:
+            raise AmbiguousElectionIdError(election_id)
 
         if election_type in self.election_id_lookup:
             return self.election_id_lookup[election_type](poll_date)
 
-        real_country = countries[country]
-
         if election_type == "local":
-            return self.local(poll_date, country=real_country)
+            return self.local(poll_date, country=country)
         elif election_type == "parl":
-            return self.uk_parliament(poll_date, country=real_country)
+            return self.uk_parliament(poll_date, country=country)
 
     def northern_ireland_assembly(self, poll_date: date) -> date:
         """

--- a/sopn_publish_date/election_ids.py
+++ b/sopn_publish_date/election_ids.py
@@ -30,18 +30,11 @@ class AmbiguousElectionIdError(BaseException):
     An exception type to represent when an election id (usually a group such as `local.2019-05-02`) can correspond to elections in multiple countries with different legislation governing the publish date of Statements of Persons Nominated.
     """
 
-    def __init__(self, election_id: str, country: str = None):
+    def __init__(self, election_id: str):
         self.election_id = election_id
-        self.country = country
 
     def __str__(self):
-        if self.country:
-            return "Election id [%s] requires a valid country, got [%s]" % (
-                self.election_id,
-                self.country,
-            )
-        else:
-            return "Cannot derive country from election id [%s]" % self.election_id
+        return "Cannot derive country from election id [%s]" % self.election_id
 
 
 def type_and_poll_date(election_id: str) -> (str, date):

--- a/sopn_publish_date/election_ids.py
+++ b/sopn_publish_date/election_ids.py
@@ -13,16 +13,35 @@ class InvalidElectionIdError(BaseException):
         return "Parameter [%s] is not in election id format" % self.election_id
 
 
+class NoSuchElectionTypeError(BaseException):
+    """
+    An exception type to represent when an election type doesn't actually represent a valid election.
+    """
+
+    def __init__(self, election_type: str):
+        self.election_type = election_type
+
+    def __str__(self):
+        return "Election type [%s] does not exist" % self.election_type
+
+
 class AmbiguousElectionIdError(BaseException):
     """
     An exception type to represent when an election id (usually a group such as `local.2019-05-02`) can correspond to elections in multiple countries with different legislation governing the publish date of Statements of Persons Nominated.
     """
 
-    def __init__(self, election_id: str):
+    def __init__(self, election_id: str, country: str = None):
         self.election_id = election_id
+        self.country = country
 
     def __str__(self):
-        return "Cannot derive country from election id [%s]" % self.election_id
+        if self.country:
+            return "Election id [%s] requires a valid country, got [%s]" % (
+                self.election_id,
+                self.country,
+            )
+        else:
+            return "Cannot derive country from election id [%s]" % self.election_id
 
 
 def type_and_poll_date(election_id: str) -> (str, date):

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -32,6 +32,11 @@ def test_publish_date_parl_id_with_country():
     assert publish_date == date(2019, 1, 25)
 
 
+def test_publish_date_europarl_id_with_country():
+    publish_date = sopn_publish_date.for_id("europarl.2019-02-21", country=Country.ENGLAND)
+
+    assert publish_date is None
+
 def test_publish_date_not_an_election_type():
 
     with raises(NoSuchElectionTypeError) as err:

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -21,26 +21,15 @@ def test_publish_date_local_id():
 
 
 def test_publish_date_local_id_with_country():
-    publish_date = sopn_publish_date.for_id("local.2019-02-21", country="ENG")
+    publish_date = sopn_publish_date.for_id("local.2019-02-21", country=Country.ENGLAND)
 
     assert publish_date == date(2019, 1, 28)
 
 
 def test_publish_date_parl_id_with_country():
-    publish_date = sopn_publish_date.for_id("parl.2019-02-21", country="ENG")
+    publish_date = sopn_publish_date.for_id("parl.2019-02-21", country=Country.ENGLAND)
 
     assert publish_date == date(2019, 1, 25)
-
-
-def test_publish_date_parl_id_with_invalid_country():
-
-    with raises(AmbiguousElectionIdError) as err:
-        sopn_publish_date.for_id("parl.2019-02-21", country="USA")
-
-    assert (
-        str(err.value)
-        == "Election id [parl.2019-02-21] requires a valid country, got [USA]"
-    )
 
 
 def test_publish_date_not_an_election_type():


### PR DESCRIPTION
* StatementPublishDate.for_id now has an optional country parameter that is expected to be in a specific set of 3-letter codes.
* If the election type doesn't actually exist, raise a new type of exception called NoSuchElectionTypeError
* If the election requires a country and either doesn't have one, or has an invalid one, raise an AmbiguousElectionIdError with extra information about the country