### PR TITLE
fix(parl): Implement date choice using the actual legislation.

### DIFF
--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -47,7 +47,7 @@ class StatementPublishDate(object):
             ]
 
         def requires_country(el_type):
-            return el_type not in self.election_id_lookup
+            return el_type in ["local", "europarl"]
 
         if not valid_election_type(election_type):
             raise NoSuchElectionTypeError(election_type)

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -159,7 +159,7 @@ class StatementPublishDate(object):
         """
         return as_date(poll_date - working_days(19, self.calendar.england_and_wales()))
 
-    def uk_parliament(self, poll_date: date, country: Country = Country.ENGLAND):
+    def uk_parliament(self, poll_date: date, country: Country = None):
         """
         Calculate the publish date for an election to the Parliament of the United Kingdom
 
@@ -169,9 +169,25 @@ class StatementPublishDate(object):
         :param country: the country in which the election is being run
         :return: a datetime representing the expected publish date
         """
-        return as_date(
-            poll_date - working_days(19, self.calendar.from_country(country))
-        )
+
+        def date_for_country(country_of_election: Country) -> date:
+            calendar = self.calendar.from_country(country_of_election)
+            return as_date(poll_date - working_days(19, calendar))
+
+        if country:
+            return date_for_country(country)
+
+        else:
+            possible_dates = [
+                date_for_country(country)
+                for country in [
+                    Country.ENGLAND,
+                    Country.SCOTLAND,
+                    Country.NORTHERN_IRELAND,
+                ]
+            ]
+
+            return min(possible_dates)
 
     def local(self, poll_date: date, country: Country):
         """

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -163,10 +163,10 @@ class StatementPublishDate(object):
         """
         Calculate the publish date for an election to the Parliament of the United Kingdom
 
-        This is set out in `Electoral Registration and Administration Act 2013 <https://www.legislation.gov.uk/ukpga/2013/6/section/14>`_
+        This is set out in `Representation of the People Act 1983 <https://www.legislation.gov.uk/ukpga/1983/2/contents>`_ and its amendments.
 
         :param poll_date: a datetime representing the date of the poll
-        :param country: the country in which the election is being run
+        :param country: an optional Country representing the country where the election will be held
         :return: a datetime representing the expected publish date
         """
 

--- a/sopn_publish_date/calendars.py
+++ b/sopn_publish_date/calendars.py
@@ -54,13 +54,17 @@ class UKBankHolidayCalendar(AbstractHolidayCalendar):
     A calendar that honours the standard 5-day week in addition to the input list of dates.
     """
 
+    @staticmethod
+    def create_holiday_from_entry(entry: dict) -> Holiday:
+        holiday_date = datetime.strptime(entry["date"], "%Y-%m-%d")
+        return holiday_from_datetime(entry["title"], holiday_date)
+
     def __init__(self, dates):
-        for bank_holiday in dates:
-            bank_holiday_date = datetime.strptime(bank_holiday["date"], "%Y-%m-%d")
-            self.rules.append(
-                holiday_from_datetime(bank_holiday["title"], bank_holiday_date)
-            )
         AbstractHolidayCalendar.__init__(self)
+
+        self.rules = [
+            UKBankHolidayCalendar.create_holiday_from_entry(entry) for entry in dates
+        ]
 
 
 class GibraltarBankHolidays(BankHolidayCalendar):

--- a/tests/test_calendars.py
+++ b/tests/test_calendars.py
@@ -1,0 +1,20 @@
+from sopn_publish_date.calendars import UnitedKingdomBankHolidays
+
+uk_calendars = UnitedKingdomBankHolidays()
+
+scotland = uk_calendars.scotland()
+england_and_wales = uk_calendars.england_and_wales()
+northern_ireland = uk_calendars.northern_ireland()
+
+
+def test_should_separate_by_country():
+
+    should_not_contain_holiday(england_and_wales, "St Patrick’s Day")
+
+    should_not_contain_holiday(scotland, "Battle of the Boyne (Orangemen’s Day)")
+
+    should_not_contain_holiday(northern_ireland, "St Andrew’s Day")
+
+
+def should_not_contain_holiday(calendar, name):
+    assert not [holiday for holiday in calendar.rules if holiday.name == name]

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -32,6 +32,12 @@ def test_publish_date_parl_id_with_country():
     assert publish_date == date(2019, 1, 25)
 
 
+def test_publish_date_parl_id_without_country():
+    publish_date = sopn_publish_date.for_id("parl.2019-02-21")
+
+    assert publish_date == date(2019, 1, 25)
+
+
 def test_publish_date_europarl_id_with_country():
     publish_date = sopn_publish_date.for_id(
         "europarl.2019-02-21", country=Country.ENGLAND

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -203,3 +203,10 @@ def test_publish_date_uk_parliament_scotland_2015():
     )
 
     assert publish_date == date(2015, 4, 9)
+
+
+# Reference election: parl.2019-12-12
+def test_publish_date_uk_parliament_2019():
+    publish_date = sopn_publish_date.uk_parliament(date(2019, 12, 12))
+
+    assert publish_date == date(2019, 11, 14)


### PR DESCRIPTION
# What?

I had misread the "Representation of the People Act" whilst implementing logic to calculate statement publish dates for UK Parliamentary elections (http://www.legislation.gov.uk/ukpga/1983/2/schedule/1/part/I/crossheading/computation-of-time/paragraph/2)

A parliamentary by-election takes into account whichever bank holidays apply in the country where the constituency is located.

A parliamentary GENERAL election means that a bank holiday in any part of the UK will count for everyone.

This became relevant in the 2019 general election, where the statement publish date is the 14th of November rather than the 15th, as the 2nd of December is St Andrew's Day in Scotland - a public holiday.

# To Do

- [x] `uk_parliament()`
- [x] `for_id()`
- [x] Docs

