### PR TITLE
fix(calendars): Do not count Christmas Eve in date calculations

### DIFF
--- a/sopn_publish_date/calendars.py
+++ b/sopn_publish_date/calendars.py
@@ -62,9 +62,15 @@ class UKBankHolidayCalendar(AbstractHolidayCalendar):
     def __init__(self, dates):
         AbstractHolidayCalendar.__init__(self)
 
-        self.rules = [
+        christmas_eve = Holiday("Christmas Eve", month=12, day=24)
+
+        days_not_counted = [
             UKBankHolidayCalendar.create_holiday_from_entry(entry) for entry in dates
         ]
+
+        days_not_counted.append(christmas_eve)
+
+        self.rules = days_not_counted
 
 
 class GibraltarBankHolidays(BankHolidayCalendar):

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -216,3 +216,17 @@ def test_publish_date_uk_parliament_2019():
     publish_date = sopn_publish_date.uk_parliament(date(2019, 12, 12))
 
     assert publish_date == date(2019, 11, 14)
+
+
+def test_christmas_eve_not_counted():
+
+    election_and_expected_sopn_date = {
+        sopn_publish_date.police_and_crime_commissioner: date(2018, 12, 11),
+        sopn_publish_date.uk_parliament: date(2018, 12, 7),
+        sopn_publish_date.scottish_parliament: date(2018, 12, 3),
+        sopn_publish_date.northern_ireland_assembly: date(2018, 12, 13),
+        sopn_publish_date.national_assembly_for_wales: date(2018, 12, 10),
+    }
+
+    for sopn_for_election_on, expected_date in election_and_expected_sopn_date.items():
+        assert sopn_for_election_on(date(2019, 1, 10)) == expected_date


### PR DESCRIPTION
* This was an error of omission.

Fixes #18 