### PR TITLE
Remove dependency on pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pandas==0.25.3
 pytest==5.3.5
 sphinx-markdown-tables==0.0.12
 pytest-cov==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     license="MIT",
     packages=find_packages(),
     package_data={"sopn_publish_date": ["bank-holidays.json"]},
-    install_requires=("pandas"),
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Topic :: Software Development",

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -1,7 +1,5 @@
 from sopn_publish_date.calendars import (
-    working_days,
     UnitedKingdomBankHolidays,
-    as_date,
     Country,
     Region,
     working_days_before,

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -5,6 +5,7 @@ from sopn_publish_date.calendars import (
     Country,
     Region,
     working_days_before,
+    FixedDates,
 )
 from sopn_publish_date.election_ids import (
     type_and_poll_date,
@@ -124,7 +125,7 @@ class StatementPublishDate(object):
         """
 
         def date_with_calendar(calendar):
-            return as_date(poll_date - working_days(19, calendar))
+            return working_days_before(poll_date, 19, calendar)
 
         if region == Region.SCOTLAND:
             return date_with_calendar(self.calendar.scotland())
@@ -133,7 +134,7 @@ class StatementPublishDate(object):
         elif region == Region.SOUTH_WEST_ENGLAND:
             return min(
                 date_with_calendar(self.calendar.england_and_wales()),
-                date_with_calendar(self.calendar.gibraltar()),
+                FixedDates.EUROPARL_GIBRALTAR_2019,
             )
         else:
             return date_with_calendar(self.calendar.england_and_wales())

--- a/sopn_publish_date/__init__.py
+++ b/sopn_publish_date/__init__.py
@@ -4,6 +4,7 @@ from sopn_publish_date.calendars import (
     as_date,
     Country,
     Region,
+    working_days_before,
 )
 from sopn_publish_date.election_ids import (
     type_and_poll_date,
@@ -74,7 +75,7 @@ class StatementPublishDate(object):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return as_date(poll_date - working_days(16, self.calendar.northern_ireland()))
+        return working_days_before(poll_date, 16, self.calendar.northern_ireland())
 
     def scottish_parliament(self, poll_date: date) -> date:
         """
@@ -85,7 +86,7 @@ class StatementPublishDate(object):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return as_date(poll_date - working_days(23, self.calendar.scotland()))
+        return working_days_before(poll_date, 23, self.calendar.scotland())
 
     def national_assembly_for_wales(self, poll_date: date) -> date:
         """
@@ -96,7 +97,7 @@ class StatementPublishDate(object):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return as_date(poll_date - working_days(19, self.calendar.england_and_wales()))
+        return working_days_before(poll_date, 19, self.calendar.england_and_wales())
 
     def greater_london_assembly(self, poll_date: date) -> date:
         """
@@ -107,7 +108,7 @@ class StatementPublishDate(object):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return as_date(poll_date - working_days(23, self.calendar.england_and_wales()))
+        return working_days_before(poll_date, 23, self.calendar.england_and_wales())
 
     def european_parliament(self, poll_date: date, region: Region) -> date:
         """
@@ -146,7 +147,7 @@ class StatementPublishDate(object):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return as_date(poll_date - working_days(18, self.calendar.england_and_wales()))
+        return working_days_before(poll_date, 18, self.calendar.england_and_wales())
 
     def mayor(self, poll_date: date) -> date:
         """
@@ -157,7 +158,7 @@ class StatementPublishDate(object):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return as_date(poll_date - working_days(19, self.calendar.england_and_wales()))
+        return working_days_before(poll_date, 19, self.calendar.england_and_wales())
 
     def uk_parliament(self, poll_date: date, country: Country = None):
         """
@@ -172,7 +173,7 @@ class StatementPublishDate(object):
 
         def date_for_country(country_of_election: Country) -> date:
             calendar = self.calendar.from_country(country_of_election)
-            return as_date(poll_date - working_days(19, calendar))
+            return working_days_before(poll_date, 19, calendar)
 
         if country:
             return date_for_country(country)
@@ -213,6 +214,6 @@ class StatementPublishDate(object):
 
         days_prior = country_specific_duration[country]
 
-        return as_date(
-            poll_date - working_days(days_prior, self.calendar.from_country(country))
+        return working_days_before(
+            poll_date, days_prior, self.calendar.from_country(country)
         )

--- a/sopn_publish_date/calendars.py
+++ b/sopn_publish_date/calendars.py
@@ -37,6 +37,10 @@ class Region(Enum):
 
 
 class FixedDates:
+    """
+    A set of fixed dates used in other calculations by this library.
+    """
+
     EUROPARL_GIBRALTAR_2019 = date(2019, 4, 24)
 
 
@@ -123,5 +127,14 @@ class UnitedKingdomBankHolidays(object):
             return self.scotland()
 
 
-def working_days_before(poll_date: date, count: int, calendar: BankHolidayCalendar):
+def working_days_before(poll_date: date, count: int, calendar: BankHolidayCalendar) -> date:
+    """
+    Return date corresponding to `count` working days before `poll_date` according to the given bank holiday calendar
+
+    :param poll_date: the date of the poll
+    :param count: the number of days before the poll date
+    :param calendar: the bank holiday calendar used in the calculation
+    :return: the calculated date
+    """
+
     return days_before(poll_date, count, calendar.exempted_dates())

--- a/sopn_publish_date/calendars.py
+++ b/sopn_publish_date/calendars.py
@@ -14,6 +14,8 @@ from pandas.tseries.holiday import (
 from pandas.tseries.offsets import CDay as BusinessDays, DateOffset
 from enum import Enum
 
+from sopn_publish_date.date import days_before, DateMatcher
+
 
 class Country(Enum):
     """
@@ -199,6 +201,15 @@ def as_date(timestamp) -> date:
     :return: the equivalent python date object
     """
     return timestamp.to_pydatetime().date()
+
+
+def working_days_before(poll_date: date, count: int, calendar: BankHolidayCalendar):
+    exempted_dates = [
+        DateMatcher(year=holiday.year, month=holiday.month, day=holiday.day)
+        for holiday in calendar.rules
+    ]
+
+    return days_before(poll_date, count, exempted_dates)
 
 
 def holiday_from_datetime(name: str, original_datetime: datetime) -> Holiday:

--- a/sopn_publish_date/calendars.py
+++ b/sopn_publish_date/calendars.py
@@ -127,14 +127,16 @@ class UnitedKingdomBankHolidays(object):
             return self.scotland()
 
 
-def working_days_before(poll_date: date, count: int, calendar: BankHolidayCalendar) -> date:
+def working_days_before(
+    end_date: date, days: int, calendar: BankHolidayCalendar
+) -> date:
     """
     Return date corresponding to `count` working days before `poll_date` according to the given bank holiday calendar
 
-    :param poll_date: the date of the poll
-    :param count: the number of days before the poll date
+    :param end_date: the date of the poll
+    :param days: the number of days before the poll date
     :param calendar: the bank holiday calendar used in the calculation
     :return: the calculated date
     """
 
-    return days_before(poll_date, count, calendar.exempted_dates())
+    return days_before(end_date, days, calendar.exempted_dates())

--- a/sopn_publish_date/calendars.py
+++ b/sopn_publish_date/calendars.py
@@ -1,18 +1,10 @@
 import json
 import os
 from datetime import datetime, date
-
-from pandas.tseries.holiday import (
-    AbstractHolidayCalendar,
-    Holiday,
-    GoodFriday,
-    EasterMonday,
-    next_monday,
-    next_monday_or_tuesday,
-    MO,
-)
-from pandas.tseries.offsets import CDay as BusinessDays, DateOffset
 from enum import Enum
+
+from pandas.tseries.holiday import AbstractHolidayCalendar, Holiday
+from pandas.tseries.offsets import CDay as BusinessDays
 
 from sopn_publish_date.date import days_before, DateMatcher
 
@@ -47,6 +39,10 @@ class Region(Enum):
     YORKSHIRE_AND_THE_HUMBER = 12
 
 
+class FixedDates:
+    EUROPARL_GIBRALTAR_2019 = date(2019, 4, 24)
+
+
 class BankHolidayCalendar(AbstractHolidayCalendar):
     pass
 
@@ -73,52 +69,6 @@ class UKBankHolidayCalendar(AbstractHolidayCalendar):
         days_not_counted.append(christmas_eve)
 
         self.rules = days_not_counted
-
-
-class GibraltarBankHolidays(BankHolidayCalendar):
-    """
-    A calendar that represents the public holidays of Gibraltar.
-    """
-
-    def __init__(self):
-        BankHolidayCalendar.__init__(
-            self,
-            rules=[
-                Holiday("New Years Day", month=1, day=1, observance=next_monday),
-                Holiday(
-                    "Commonwealth Day", month=3, day=1, offset=DateOffset(weekday=MO(2))
-                ),
-                GoodFriday,
-                EasterMonday,
-                Holiday("Worker's Day", month=4, day=28, observance=next_monday),
-                Holiday(
-                    "Early May bank holiday",
-                    month=5,
-                    day=1,
-                    offset=DateOffset(weekday=MO(1)),
-                ),
-                Holiday(
-                    "Spring bank holiday",
-                    month=5,
-                    day=31,
-                    offset=DateOffset(weekday=MO(-1)),
-                ),
-                Holiday(
-                    "Queen's Birthday", month=6, day=1, offset=DateOffset(weekday=MO(2))
-                ),
-                Holiday(
-                    "Summer bank holiday",
-                    month=8,
-                    day=31,
-                    offset=DateOffset(weekday=MO(-1)),
-                ),
-                Holiday("Gibraltar Day", month=9, day=10, observance=next_monday),
-                Holiday("Christmas Day", month=12, day=25, observance=next_monday),
-                Holiday(
-                    "Boxing Day", month=12, day=26, observance=next_monday_or_tuesday
-                ),
-            ],
-        )
 
 
 class UnitedKingdomBankHolidays(object):
@@ -148,12 +98,6 @@ class UnitedKingdomBankHolidays(object):
         :return: a calendar representation of bank holidays in England and Wales
         """
         return self._calendar["england-and-wales"]
-
-    def gibraltar(self) -> BankHolidayCalendar:
-        """
-        :return: a calendar representation of bank holidays in Gibraltar
-        """
-        return GibraltarBankHolidays()
 
     def scotland(self) -> BankHolidayCalendar:
         """

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -9,10 +9,12 @@ def days_before(poll_date: date, days: int, exempted_days: List[date] = []) -> d
     while days > 0:
         poll_date -= timedelta(days=1)
 
-        if (
-            poll_date.weekday() not in [SATURDAY, SUNDAY]
-            and poll_date not in exempted_days
-        ):
-            days -= 1
+        if poll_date.weekday() in [SATURDAY, SUNDAY]:
+            continue
+
+        if poll_date in exempted_days:
+            continue
+
+        days -= 1
 
     return poll_date

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -5,14 +5,33 @@ SATURDAY = 5
 SUNDAY = 6
 
 
-def days_before(poll_date: date, days: int, exempted_days: List[date] = []) -> date:
+class DateMatcher:
+    def __init__(self, day, month, year=None):
+        self.month = month
+        self.day = day
+        self.year = year
+
+    def matches(self, other: date):
+        if self.day != other.day:
+            return False
+
+        if self.month != other.month:
+            return False
+
+        if self.year is not None and self.year != other.year:
+            return False
+
+        return True
+
+
+def days_before(poll_date: date, days: int, ignore: List[DateMatcher] = []) -> date:
     while days > 0:
         poll_date -= timedelta(days=1)
 
         if poll_date.weekday() in [SATURDAY, SUNDAY]:
             continue
 
-        if poll_date in exempted_days:
+        if any([day.matches(poll_date) for day in ignore]):
             continue
 
         days -= 1

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -6,13 +6,23 @@ SUNDAY = 6
 
 
 class DateMatcher:
-    def __init__(self, day, month, year=None, name=None):
+    """
+    An object that represents a matcher against datetime.date objects, given a day, a month, and an optional year.
+    """
+
+    def __init__(self, day: int, month: int, year: int = None, name: str = None):
         self.name = name
         self.month = month
         self.day = day
         self.year = year
 
-    def matches(self, other: date):
+    def matches(self, other: date) -> bool:
+        """
+        Return whether the input date matches the attributes of this class
+
+        :param other: the date being matched against
+        :return a boolean representing whether the input matched against this class's attributes
+        """
         if self.day != other.day:
             return False
 
@@ -25,7 +35,16 @@ class DateMatcher:
         return True
 
 
-def days_before(poll_date: date, days: int, ignore: List[DateMatcher] = []) -> date:
+def days_before(poll_date: date, days: int, ignore: List[DateMatcher] = None) -> date:
+    """
+    Return date corresponding to `days` working days before `poll_date`, not counting the list of provided exemptions
+
+    :param poll_date: the date of the poll
+    :param days: the number of days before the poll date
+    :param ignore: the list of DateMatchers to ignore in the look-back calculation
+    :return: the calculated date
+    """
+
     while days > 0:
         poll_date -= timedelta(days=1)
 

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -6,7 +6,8 @@ SUNDAY = 6
 
 
 class DateMatcher:
-    def __init__(self, day, month, year=None):
+    def __init__(self, day, month, year=None, name=None):
+        self.name = name
         self.month = month
         self.day = day
         self.year = year

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -1,14 +1,18 @@
+from typing import List
 from datetime import date, timedelta
 
 SATURDAY = 5
 SUNDAY = 6
 
 
-def days_before(poll_date: date, days: int) -> date:
+def days_before(poll_date: date, days: int, exempted_days: List[date] = []) -> date:
     while days > 0:
         poll_date -= timedelta(days=1)
 
-        if poll_date.weekday() not in [SATURDAY, SUNDAY]:
+        if (
+            poll_date.weekday() not in [SATURDAY, SUNDAY]
+            and poll_date not in exempted_days
+        ):
             days -= 1
 
     return poll_date

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -1,11 +1,14 @@
 from datetime import date, timedelta
 
+SATURDAY = 5
+SUNDAY = 6
+
 
 def days_before(poll_date: date, days: int) -> date:
     while days > 0:
         poll_date -= timedelta(days=1)
 
-        if poll_date.weekday() not in [5, 6]:
+        if poll_date.weekday() not in [SATURDAY, SUNDAY]:
             days -= 1
 
     return poll_date

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -51,7 +51,7 @@ def days_before(poll_date: date, days: int, ignore: List[DateMatcher] = None) ->
         if poll_date.weekday() in [SATURDAY, SUNDAY]:
             continue
 
-        if any([day.matches(poll_date) for day in ignore]):
+        if ignore and any([day.matches(poll_date) for day in ignore]):
             continue
 
         days -= 1

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -1,0 +1,5 @@
+from datetime import date
+
+
+def days_before(poll_date: date, days: int) -> date:
+    return poll_date

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -2,4 +2,10 @@ from datetime import date, timedelta
 
 
 def days_before(poll_date: date, days: int) -> date:
-    return poll_date - timedelta(days=days)
+    while days > 0:
+        poll_date -= timedelta(days=1)
+
+        if poll_date.weekday() not in [5, 6]:
+            days -= 1
+
+    return poll_date

--- a/sopn_publish_date/date.py
+++ b/sopn_publish_date/date.py
@@ -1,5 +1,5 @@
-from datetime import date
+from datetime import date, timedelta
 
 
 def days_before(poll_date: date, days: int) -> date:
-    return poll_date
+    return poll_date - timedelta(days=days)

--- a/tests/test_calendars.py
+++ b/tests/test_calendars.py
@@ -17,4 +17,6 @@ def test_should_separate_by_country():
 
 
 def should_not_contain_holiday(calendar, name):
-    assert not [holiday for holiday in calendar.rules if holiday.name == name]
+    assert not [
+        holiday for holiday in calendar.exempted_dates() if holiday.name == name
+    ]

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -13,3 +13,9 @@ def test_non_zero_days_before():
 
     assert days_before(example, 1) == date(2019, 12, 31)
     assert days_before(example, 2) == date(2019, 12, 30)
+
+
+def test_ignore_weekends():
+    example = date(2020, 1, 6)  # Monday
+
+    assert days_before(example, 1) == date(2020, 1, 3)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,0 +1,8 @@
+from sopn_publish_date.date import days_before
+from datetime import date
+
+
+def test_zero_days_before():
+    example = date(2020, 1, 1)
+
+    assert days_before(example, 0) == example

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,4 +1,4 @@
-from sopn_publish_date.date import days_before
+from sopn_publish_date.date import days_before, DateMatcher
 from datetime import date
 
 
@@ -21,9 +21,17 @@ def test_ignore_weekends():
     assert days_before(example, 1) == date(2020, 1, 3)
 
 
-def test_ignore_exempted_days():
+def test_ignore_exempted_day_with_year():
     example = date(2020, 1, 1)
 
-    exempted_dates = [date(2019, 12, 31)]
+    exempted_dates = [DateMatcher(year=2019, month=12, day=31)]
+
+    assert days_before(example, 1, exempted_dates) == date(2019, 12, 30)
+
+
+def test_ignore_exempted_day_without_year():
+    example = date(2020, 1, 1)
+
+    exempted_dates = [DateMatcher(month=12, day=31)]
 
     assert days_before(example, 1, exempted_dates) == date(2019, 12, 30)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -6,3 +6,10 @@ def test_zero_days_before():
     example = date(2020, 1, 1)
 
     assert days_before(example, 0) == example
+
+
+def test_non_zero_days_before():
+    example = date(2020, 1, 1)
+
+    assert days_before(example, 1) == date(2019, 12, 31)
+    assert days_before(example, 2) == date(2019, 12, 30)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -19,3 +19,11 @@ def test_ignore_weekends():
     example = date(2020, 1, 6)  # Monday
 
     assert days_before(example, 1) == date(2020, 1, 3)
+
+
+def test_ignore_exempted_days():
+    example = date(2020, 1, 1)
+
+    exempted_dates = [date(2019, 12, 31)]
+
+    assert days_before(example, 1, exempted_dates) == date(2019, 12, 30)


### PR DESCRIPTION
This PR breaks the dependency on Pandas for date calculation.

The new implementation is faster, has fewer external dependencies, and encouraged a refactoring to remove the need for a thorough implementation of the Gibraltar calendar, since the UK will not be participating in EU elections again.